### PR TITLE
Fix category dropdown by using correct database column names (CategoryId, CategoryName)

### DIFF
--- a/includes/add-expenses.php
+++ b/includes/add-expenses.php
@@ -247,21 +247,23 @@ if (strlen($_SESSION['detsuid'] == 0)) {
                   </div>
 
 
-                  <div class="form-group">
+                 <div class="form-group">
                     <label for="category">Category</label>
                     <select class="form-control" id="category" name="category" required>
-                      <option value="" selected disabled>Choose Category</option>
-                      <?php
-                      $userid = $_SESSION['detsuid'];
-                      $query = "SELECT * FROM tblcategory WHERE userid = $userid AND mode = 'expense' ";
-                      $result = mysqli_query($db, $query);
-                      while ($row = mysqli_fetch_assoc($result)) {
-                        // Display category options in a dropdown
-                        echo '<option value="' . $row['categoryid'] . '">' . $row['categoryname'] . '</option>';
-                      }
-                      ?>
+                        <option value="" selected disabled>Choose Category</option>
+                        <?php
+                        $userid = $_SESSION['detsuid'];
+                        $query = "SELECT CategoryId, CategoryName FROM tblcategory 
+                                  WHERE UserId = $userid AND Mode = 'expense'";
+                        $result = mysqli_query($db, $query);
+
+                        while ($row = mysqli_fetch_assoc($result)) {
+                            echo '<option value="' . $row['CategoryId'] . '">' . $row['CategoryName'] . '</option>';
+                        }
+                        ?>
                     </select>
-                  </div>
+                </div>
+
 
                   <div class="form-group">
                     <label for="costitem">Cost of Item</label>

--- a/includes/add-income.php
+++ b/includes/add-income.php
@@ -226,16 +226,19 @@ if (strlen($_SESSION['detsuid'] == 0)) {
                                             <option value="" selected disabled>Choose Category</option>
                                             <?php
                                             $userid = $_SESSION['detsuid'];
-                                            // Fetch only income categories (assuming a 'type' column or similar in tblcategory)
-                                            // If you don't have a 'type' column, you might need a separate table for income categories or filter differently.
-                                            $query = "SELECT * FROM tblcategory WHERE userid = $userid AND mode = 'income'";
+
+                                            $query = "SELECT CategoryId, CategoryName FROM tblcategory 
+                                                    WHERE UserId = $userid AND Mode = 'income'";
                                             $result = mysqli_query($db, $query);
+
                                             while ($row = mysqli_fetch_assoc($result)) {
-                                                echo '<option value="' . $row['categoryid'] . '">' . $row['categoryname'] . '</option>';
+                                                echo '<option value="' . $row['CategoryId'] . '">' . $row['CategoryName'] . '</option>';
                                             }
                                             ?>
                                         </select>
                                     </div>
+
+
 
                                     <div class="form-group">
                                         <label for="incomeAmount">Amount of Income</label>


### PR DESCRIPTION
Updated the category dropdown queries in add-expenses.php and add-income.php to use the correct 
column names from tblcategory.

The previous code referenced 'categoryid' and 'categoryname', which do not exist in the database.
This resulted in dropdown options appearing with empty values and blank text.

Replaced those with 'CategoryId' and 'CategoryName', matching the actual schema:
- CategoryId (primary key)
- CategoryName (category label)

This fix restores proper dropdown functionality for both expense and income categories.
